### PR TITLE
add simple deprecated types

### DIFF
--- a/Data/Bson/Binary.hs
+++ b/Data/Bson/Binary.hs
@@ -94,17 +94,19 @@ getField = do
            0x05 -> return $ Md5 (MD5 b)
            0x80 -> return $ UserDef (UserDefined b)
            _ -> fail $ "unknown Bson binary subtype " ++ show s
+        0x06 -> return Null
         0x07 -> ObjId <$> getObjectId
         0x08 -> Bool <$> getBool
         0x09 -> UTC <$> getUTC
         0x0A -> return Null
         0x0B -> RegEx <$> getRegex
         0x0D -> JavaScr . Javascript [] <$> getString
+        0x0E -> String <$> getString
         0x0F -> JavaScr . uncurry (flip Javascript) <$> getClosure
         0x0E -> Sym <$> getSymbol
         0x10 -> Int32 <$> getInt32
-        0x12 -> Int64 <$> getInt64
         0x11 -> Stamp <$> getMongoStamp
+        0x12 -> Int64 <$> getInt64
         0xFF -> return (MinMax MinKey)
         0x7F -> return (MinMax MaxKey)
         _ -> fail $ "unknown Bson value type " ++ show t

--- a/Data/Bson/Binary.hs
+++ b/Data/Bson/Binary.hs
@@ -100,10 +100,10 @@ getField = do
         0x09 -> UTC <$> getUTC
         0x0A -> return Null
         0x0B -> RegEx <$> getRegex
+        0x0C -> ObjId <$> getObjectId <* getString
         0x0D -> JavaScr . Javascript [] <$> getString
-        0x0E -> String <$> getString
-        0x0F -> JavaScr . uncurry (flip Javascript) <$> getClosure
         0x0E -> Sym <$> getSymbol
+        0x0F -> JavaScr . uncurry (flip Javascript) <$> getClosure
         0x10 -> Int32 <$> getInt32
         0x11 -> Stamp <$> getMongoStamp
         0x12 -> Int64 <$> getInt64


### PR DESCRIPTION
Hello,

I've used the library against a mongodb 2.6 instance. The library throws an error when parsing [deprecated bson types](https://docs.mongodb.com/manual/reference/bson-types/) fields. This bug makes it impossible to deal with legacy systems.

I suggest to implement deprecated types and make them fallback over known equivalent types.

1. 0x06 `undefined`: I suggest to parse it as a `Null` field
2. ~~0x0E `symbol`: I thought it could easily fallback under `String`, but I notice the presence of `Symbol` in the tests suite, should it be replaced by it?~~ This case was already supported

This leaves with 2 unsupported types:

1. 0x0C `DBPointer`: I am unsure to what to convert iit to. Should we create another type `DBPointer` or fallback on `ObjectId`. I am not using this field myself, so I'm clueless.
2. 0x13 `Decimal128`: the haskell [IEEE754](https://hackage.haskell.org/package/data-binary-ieee754-0.4.4/docs/Data-Binary-IEEE754.html) parsing library does not support decimal128 parsing, I suggest to contribute there in order to support this field (note: it's not a deprecated field, but a new field).

Thanks for reviewing my suggestions.