### PR TITLE
Switch to non-deprecated versions of dependencies

### DIFF
--- a/bson.cabal
+++ b/bson.cabal
@@ -23,16 +23,27 @@ Cabal-version: >= 1.10
 Build-type:    Simple
 Extra-Source-Files: CHANGELOG.md
 
+Flag _old-network
+  description: Control whether to use <http://hackage.haskell.org/package/network-bsd network-bsd>
+  default: False
+  manual: False
+
 Library
   Build-depends:      base < 5
                     , time
                     , bytestring
                     , binary >= 0.5 && < 0.9
-                    , cryptohash
+                    , cryptohash-md5 == 0.11.*
                     , data-binary-ieee754
                     , mtl >= 2
-                    , network
                     , text >= 0.11
+
+  if flag(_old-network)
+     -- "Network.BSD" is only available in network < 2.9
+     build-depends: network < 2.9
+  else
+     -- "Network.BSD" has been moved into its own package `network-bsd`
+     build-depends: network-bsd >= 2.7 && < 2.9
 
   Default-Language: Haskell2010
   Default-Extensions: BangPatterns, CPP
@@ -46,24 +57,23 @@ Source-repository head
 
 Test-suite bson-tests
   Type:             exitcode-stdio-1.0
-  Hs-source-dirs:   tests .
+  Hs-source-dirs:   tests
   Main-is:          Tests.hs
   Other-modules:    Data.Bson.Binary.Tests
                     Data.Bson.Tests
   Ghc-options:      -Wall -fno-warn-orphans
 
-  Build-depends:      test-framework             >= 0.4
+  -- NB: we depend here on the intra-package lib:bson componant
+  Build-depends:    bson
+                    -- test-specific dependencies
+                    , test-framework             >= 0.4
                     , test-framework-quickcheck2 >= 0.2
                     , QuickCheck                 >= 2.4
-                    -- Copied from regular dependencies...
-                    , base < 5
+                    -- dependency constraints inherited from lib:bson component
+                    , base
                     , time
                     , bytestring
-                    , binary >= 0.5 && < 0.9
-                    , cryptohash
-                    , data-binary-ieee754
-                    , mtl >= 2
-                    , network
-                    , text >= 0.11
+                    , text
+
   Default-Language: Haskell2010
   Default-Extensions: CPP

--- a/bson.cabal
+++ b/bson.cabal
@@ -25,7 +25,6 @@ Extra-Source-Files: CHANGELOG.md
 
 Flag _old-network
   description: Control whether to use <http://hackage.haskell.org/package/network-bsd network-bsd>
-  default: False
   manual: False
 
 Library


### PR DESCRIPTION
This makes `bson` compatible with the non-backward-compatible `network-3.0` release

This retains support for legacy versions of `network` but
prefers the new `network-bsd` package when possible

While at it, the test-suite component's description in the
cabal file has been simplified and made more idiomatic by
using an intra-package dependency on lib:bson.
