### PR TITLE
Assign empty labels to array elements for better efficiency

### DIFF
--- a/Data/Bson/Binary.hs
+++ b/Data/Bson/Binary.hs
@@ -171,8 +171,7 @@ getDocument = do
    else (:) <$> getField <*> getFields
 
 putArray :: [Value] -> Put
-putArray vs = putDocument (zipWith f [0..] vs)
-  where f i v = (T.pack $! show i) := v
+putArray vs = putDocument (map (T.empty :=) vs)
 
 getArray :: Get [Value]
 getArray = map value <$> getDocument


### PR DESCRIPTION
Right now this package assigns consecutive integer numbers (serialized as strings) for array labels. This is wasteful in both space and time.

This PR addresses the issue as far as possible within the BSON spec.

In my example, this reduced the serialziation time from 1.5s to 1s and the file size from 45Mb to 32Mb.