### PR TITLE
Migrate to MonadFail for GHC-8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: haskell
+ghc:
+  - "8.2"
+  - "8.4"
+  - "8.6"
+  - "8.8"
 
 jobs:
   include:
@@ -20,3 +25,4 @@ jobs:
         on:
           repo: mongodb-haskell/bson
           tags: true
+          ghc: "8.6"

--- a/bson.cabal
+++ b/bson.cabal
@@ -28,7 +28,7 @@ Flag _old-network
   manual: False
 
 Library
-  Build-depends:      base < 5
+  Build-depends:      base >= 4.9.0.0 && < 5
                     , time
                     , bytestring
                     , binary >= 0.5 && < 0.9


### PR DESCRIPTION
This commit uses CPP to make bson compatible with both 8.8 and older
GHCs. It was tested with 8.4, 8.6 and 8.8.

--

This is simplified form of #20 by @tfausak. It should compile without warning on all GHC versions.