### PR TITLE
Fix MonadFail usage

### DIFF
--- a/Data/Bson.hs
+++ b/Data/Bson.hs
@@ -29,7 +29,7 @@ import Prelude hiding (fail, lookup)
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
 #endif
-#if !MIN_VERSION_base(4,13,0)
+#if MIN_VERSION_base(4, 9, 0)
 import Control.Monad.Fail (MonadFail(fail))
 #endif
 import Control.Monad (foldM)

--- a/Data/Bson.hs
+++ b/Data/Bson.hs
@@ -25,12 +25,12 @@ module Data.Bson (
   ObjectId(..), timestamp, genObjectId, showHexLen
 ) where
 
-import Prelude hiding (lookup)
+import Prelude hiding (fail, lookup)
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
 #endif
 #if !MIN_VERSION_base(4,13,0)
-import Control.Monad.Fail (MonadFail)
+import Control.Monad.Fail (MonadFail(fail))
 #endif
 import Control.Monad (foldM)
 import Data.Bits (shift, (.|.))


### PR DESCRIPTION
Previously, the code was using `fail` from `Prelude` instead of from `Control.Monad.Fail`.

Consider:

```haskell
{-# LANGUAGE FlexibleInstances, OverloadedStrings #-}

import Control.Monad.Fail
import Data.Bson

instance MonadFail (Either String) where
   fail = Left

main = print (look "hi" [] :: Either String Value)
```

Before this fix, the result is:

    *** Exception: expected "hi" in []

After the fix, it's:

    Left "expected \"hi\" in []"
