### PR TITLE
Fix build for Nix

### DIFF
--- a/bson.cabal
+++ b/bson.cabal
@@ -25,7 +25,8 @@ Extra-Source-Files: CHANGELOG.md
 
 Flag _old-network
   description: Control whether to use <http://hackage.haskell.org/package/network-bsd network-bsd>
-  manual: False
+  manual: True
+  default: False
 
 Library
   Build-depends:      base >= 4.9.0.0 && < 5


### PR DESCRIPTION
cf this fork: https://github.com/chessai/bson credit to @chessai for figuring this out

We're depending on this fork because the `bson-0.4.0.1` in NixPkgs is marked as broken. I do not know how or why it is broken. But this fixes it up just fine.